### PR TITLE
Add command line option '-C' to provide CA bundle [file]

### DIFF
--- a/include/onomondo/ipa/http.h
+++ b/include/onomondo/ipa/http.h
@@ -2,7 +2,7 @@
 
 struct ipa_buf;
 
-void *ipa_http_init(void);
+void *ipa_http_init(const char *cabundle);
 int ipa_http_req(void *http_ctx, struct ipa_buf *res, const struct ipa_buf *req, const char *url);
 void ipa_http_close(void *http_ctx);
 void ipa_http_free(void *http_ctx);

--- a/include/onomondo/ipa/ipad.h
+++ b/include/onomondo/ipa/ipad.h
@@ -43,6 +43,9 @@ struct ipa_config {
 	uint8_t tac[IPA_LEN_TAC];
 
 	/*! The caller may choose to disable SSL in a test environment to simplify debugging. */
+	const char *eim_cabundle;
+
+	/*! The caller may choose to disable SSL in a test environment to simplify debugging. */
 	bool eim_disable_ssl;
 
 	/*! Configure the number of retries to apply in case a request (HTTP) to the eIM fails */

--- a/src/ipa/libipa/ipad.c
+++ b/src/ipa/libipa/ipad.c
@@ -164,7 +164,7 @@ int ipa_init(struct ipa_context *ctx)
 {
 	int rc;
 
-	ctx->http_ctx = ipa_http_init();
+	ctx->http_ctx = ipa_http_init(ctx->cfg->eim_cabundle);
 	if (!ctx->http_ctx)
 		return -EINVAL;
 


### PR DESCRIPTION
This option allows us to override the operating system default list of root certificates for the X.509 certificate verification of the ESipa SSL connection.

For curl, this could also have been achieved by setting the CURL_CA_BUNDLE environment variable.  However, as in the future there might be other HTTP[s] backends, let's make sure to have an uniform method how the IPAd user can specify the CA certificate bundle to be used.

I haven't tested this yet, but in general I can e.g. make something like `curl --cacert CERT_CI_ECDSA_NIST.pem https://smdpp.test.rsp.sysmocom.de/` work on Debian 12; this should effectively trigger the same code paths in libcurl.  It also works via `CURL_CA_BUNDLE=CERT_CI_ECDSA_NIST.pem curl https://smdpp.test.rsp.sysmocom.de/`