### PR TITLE
README.md: Add a note about SGP.32 v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ element in the 3GPP IoT eSIM system as described in SGP.31 and SGP.32. It interf
 and the eIM (via HTTPS) on the other side. The implementation presented here can run on a regular Linux host. It can also be used
 as a library to add IPAd functionality to an IoT device that runs an RTOS.
 
+This code currently implements SGP.32 v1.0, an early version
+of the GSMA specifications which did never get used in production.  The only SAS-SM accredited eUICCs
+implemented the later SGP.32 v1.2. For differences, see
+this [summary of SGP.32 changes](https://osmocom.org/projects/sim-card-related/wiki/GSMA_SGP32_ChangeLog).
 
 Interfaces
 ----------


### PR DESCRIPTION
Clarifying the supported version will help potential users avoid spending a lot of time looking at why it won't work with present-day eUICCs.